### PR TITLE
fix(wear): properly request Wi-Fi network when needed

### DIFF
--- a/app-wear/src/main/java/fr/outadoc/homeslide/wear/rest/baseurl/WearBaseUrlProvider.kt
+++ b/app-wear/src/main/java/fr/outadoc/homeslide/wear/rest/baseurl/WearBaseUrlProvider.kt
@@ -45,9 +45,12 @@ class WearBaseUrlProvider(
 
     private val localBaseUri: HttpUrl?
         get() {
-            // When remote URL has failed once, we want to request a Wi-Fi network
-            // because we know it's going to be more reliable, especially for local network access.
-            requestWiFiNetworkBlocking()
+            if (currentWifiNetwork == null) {
+                // When remote URL has failed once, we want to request a Wi-Fi network
+                // because we know it's going to be more reliable, especially for local network access.
+                requestWiFiNetworkBlocking()
+            }
+
             connectivityManager.bindProcessToNetwork(currentWifiNetwork)
             return config.localInstanceBaseUrl.toUrlOrNull()
         }
@@ -62,6 +65,8 @@ class WearBaseUrlProvider(
 
     private var currentWifiNetwork: Network? = null
         set(value) {
+            if (value === field) return
+
             if (value == null) {
                 KLog.d { "Disconnected from Wi-Fi, preferring remote base URL" }
             } else {

--- a/app-wear/src/main/java/fr/outadoc/homeslide/wear/rest/baseurl/WearBaseUrlProvider.kt
+++ b/app-wear/src/main/java/fr/outadoc/homeslide/wear/rest/baseurl/WearBaseUrlProvider.kt
@@ -45,13 +45,13 @@ class WearBaseUrlProvider(
 
     private val localBaseUri: HttpUrl?
         get() {
-            if (currentWifiNetwork == null) {
+            if (currentWiFiNetwork == null) {
                 // When remote URL has failed once, we want to request a Wi-Fi network
                 // because we know it's going to be more reliable, especially for local network access.
                 requestWiFiNetworkBlocking()
             }
 
-            connectivityManager.bindProcessToNetwork(currentWifiNetwork)
+            connectivityManager.bindProcessToNetwork(currentWiFiNetwork)
             return config.localInstanceBaseUrl.toUrlOrNull()
         }
 
@@ -63,7 +63,7 @@ class WearBaseUrlProvider(
 
     private var preferLocalBaseUrl: Boolean = false
 
-    private var currentWifiNetwork: Network? = null
+    private var currentWiFiNetwork: Network? = null
         set(value) {
             if (value === field) return
 
@@ -77,29 +77,29 @@ class WearBaseUrlProvider(
             preferLocalBaseUrl = value != null
         }
 
-    private val wifiRequest = NetworkRequest.Builder()
+    private val wiFiRequest = NetworkRequest.Builder()
         .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
         .build()
 
     init {
         // Listen for Wi-Fi state changes
         connectivityManager.registerNetworkCallback(
-            wifiRequest,
+            wiFiRequest,
             object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
-                    currentWifiNetwork = network
+                    currentWiFiNetwork = network
                 }
 
                 override fun onLost(network: Network) {
-                    currentWifiNetwork = null
+                    currentWiFiNetwork = null
                 }
             })
     }
 
     private fun requestWiFiNetworkBlocking() {
         runBlocking {
-            currentWifiNetwork =
-                connectivityManager.requestNetwork(wifiRequest, WIFI_REQUEST_TIMEOUT_MS)
+            currentWiFiNetwork =
+                connectivityManager.requestNetwork(wiFiRequest, WIFI_REQUEST_TIMEOUT_MS)
         }
     }
 

--- a/lib-restclient/build.gradle.kts
+++ b/lib-restclient/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
     implementation(Dependencies.AndroidX.core)
     implementation(Dependencies.AndroidX.appcompat)
 
+    implementation(Dependencies.Kotlin.Coroutines.core)
+
     // Network libs
     implementation(Dependencies.Retrofit.core)
 

--- a/lib-restclient/src/main/java/fr/outadoc/homeslide/rest/ConnectivityManagerExt.kt
+++ b/lib-restclient/src/main/java/fr/outadoc/homeslide/rest/ConnectivityManagerExt.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Baptiste Candellier
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package fr.outadoc.homeslide.rest
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkRequest
+import android.os.Build
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.resume
+
+suspend fun ConnectivityManager.requestNetwork(request: NetworkRequest, timeoutMs: Int): Network? =
+    withTimeout(timeoutMs.toLong()) {
+        suspendCancellableCoroutine { cont ->
+            val callback = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    cont.resume(network)
+                }
+
+                override fun onUnavailable() {
+                    cont.resume(null)
+                }
+
+                override fun onLost(network: Network) {
+                    cont.resume(null)
+                }
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                requestNetwork(request, callback, timeoutMs)
+            } else {
+                requestNetwork(request, callback)
+            }
+
+            cont.invokeOnCancellation {
+                unregisterNetworkCallback(callback)
+            }
+        }
+    }

--- a/lib-restclient/src/main/java/fr/outadoc/homeslide/rest/ConnectivityManagerExt.kt
+++ b/lib-restclient/src/main/java/fr/outadoc/homeslide/rest/ConnectivityManagerExt.kt
@@ -20,9 +20,9 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
 import android.os.Build
+import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
-import kotlin.coroutines.resume
 
 suspend fun ConnectivityManager.requestNetwork(request: NetworkRequest, timeoutMs: Int): Network? =
     withTimeout(timeoutMs.toLong()) {


### PR DESCRIPTION
On Wear OS, request Wi-Fi network using `ConnectivityManager.requestNetwork()` instead of just observing with `registerNetworkCallback()`.

To properly connect *before* trying to load the URL, I'm trying to make a blocking call to `requestNetwork()`, with the help of a cancellable coroutine and a timeout.

Unless I'm missing something again this should make things... work? 😛 

Based on @zeroos' work — thanks again to them! https://github.com/outadoc/home-slide-android/compare/9e875fc6b31f59181c1b05bfdb0d9661321b07e1...zeroos:e03e3fff895bfefb093d431c8c9996860b7ec85e