### PR TITLE
release(1.6.0)

### DIFF
--- a/buildSrc/src/main/kotlin/AppInfo.kt
+++ b/buildSrc/src/main/kotlin/AppInfo.kt
@@ -17,8 +17,8 @@
 @Suppress("MemberVisibilityCanBePrivate")
 object AppInfo {
 
-    const val versionName = "1.5.11"
-    const val baseVersionCode = 161
+    const val versionName = "1.6.0"
+    const val baseVersionCode = 162
 
     const val targetSdkVersion = 30
 

--- a/changelog/whatsnew-en-US
+++ b/changelog/whatsnew-en-US
@@ -1,6 +1,11 @@
-Home Slide is now open-source!
-You can browse and support the project by tapping on the link in the "About" screen.
+This release focuses on stability.
 
-domain: add support for scene domain (#352)
-mdi: extract mdi to its own project (#340)
-wear: fix about background on wear os (#350)
+Fixes:
+- Improve base url selection
+- Properly request Wi-Fi network when needed
+
+Special thanks to @zeroos for their help on improving network access on Wear OS!
+
+Chores:
+- Update Material Design Icons to 5.9.55
+- Update other dependencies

--- a/changelog/whatsnew-fr-FR
+++ b/changelog/whatsnew-fr-FR
@@ -1,6 +1,11 @@
-Home Slide est maintenant open-source !
-Vous pouvez parcourir et supporter le projet en tapant sur le lien dans l'écran "À propos".
+Cette version cible une meilleure stabilité de l'app.
 
-domain: ajouté le support du domaine scene (#352)
-mdi: extracté mdi dans son propre projet (#340)
-wear: corrigé l'écran à propos sur wear os (#350)
+Correctifs :
+- Améliorations de la sélection de l'URL de l'instance à utiliser
+- L'app Wear OS demande maintenant la connexion Wi-Fi à la montre si disponible
+
+Mention spéciale à @zeroos pour leur aide sur l'amélioration de la gestion réseau sur Wear OS !
+
+Autres :
+- Mise à jour de Material Design Icons en 5.9.55
+- Mise à jour d'autres dépendances


### PR DESCRIPTION
Release version 1.6.0 - as a internal test for now, will expand to beta if stable enough, then eventually to stable.