### PR TITLE
feat(grid): add filter box in edit mode

### DIFF
--- a/app/src/main/java/fr/outadoc/homeslide/app/feature/grid/ui/EntityGridFragment.kt
+++ b/app/src/main/java/fr/outadoc/homeslide/app/feature/grid/ui/EntityGridFragment.kt
@@ -37,6 +37,7 @@ import androidx.core.os.postDelayed
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavDeepLinkBuilder
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -58,6 +59,7 @@ import fr.outadoc.homeslide.common.feature.grid.vm.EntityListViewModel.State
 import fr.outadoc.homeslide.hassapi.model.entity.base.Entity
 import fr.outadoc.homeslide.logging.KLog
 import fr.outadoc.homeslide.rest.NetworkAccessManager
+import fr.outadoc.homeslide.util.view.addTextChangedListener
 import fr.outadoc.homeslide.util.view.showSnackbar
 import io.uniflow.androidx.flow.onEvents
 import io.uniflow.androidx.flow.onStates
@@ -149,6 +151,10 @@ class EntityGridFragment : Fragment() {
                 vm.loadEntities()
             }
 
+            editTextShortcutsFilter.addTextChangedListener { filter ->
+                vm.onFilterChange(filter)
+            }
+
             skeleton = recyclerViewShortcuts.applySkeleton(
                 listItemLayoutResId = R.layout.item_shortcut_shimmer,
                 itemCount = SKELETON_ITEM_COUNT
@@ -220,7 +226,7 @@ class EntityGridFragment : Fragment() {
         itemAdapter.apply {
             when (state) {
                 is State.Content -> submitList(state.displayTiles)
-                is State.Editing -> submitList(state.tiles)
+                is State.Editing -> submitList(state.displayTiles)
                 is State.InitialError -> {
                     binding?.layoutNoContent?.textViewNoContentErrorMessage?.apply {
                         text = state.errorMessage
@@ -258,6 +264,8 @@ class EntityGridFragment : Fragment() {
         binding?.recyclerViewShortcuts?.setOnTouchListener { _, _ ->
             state is State.InitialLoading
         }
+
+        binding?.textInputLayoutShortcutsFilter?.isVisible = state is State.Editing
 
         binding?.viewFlipperEntityGrid?.apply {
             if (displayedChild != childToDisplay) {

--- a/app/src/main/res/layout/fragment_entity_grid.xml
+++ b/app/src/main/res/layout/fragment_entity_grid.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2020 Baptiste Candellier
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +15,7 @@
   -->
 
 <ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/viewFlipper_entityGrid"
     android:layout_width="match_parent"
@@ -24,18 +24,41 @@
     android:inAnimation="@anim/fade_in"
     android:outAnimation="@anim/fade_out">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView_shortcuts"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"
-        android:focusable="false"
-        android:paddingHorizontal="16dp"
-        android:scrollbarStyle="outsideOverlay"
-        tools:itemCount="20"
-        tools:layoutManager="GridLayoutManager"
-        tools:listitem="@layout/item_shortcut"
-        tools:spanCount="3" />
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textInputLayout_shortcuts_filter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/grid_filter_hint"
+            android:padding="16dp"
+            app:endIconMode="clear_text">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editText_shortcuts_filter"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:imeOptions="actionSearch" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView_shortcuts"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:focusable="false"
+            android:paddingHorizontal="16dp"
+            android:scrollbarStyle="outsideOverlay"
+            tools:itemCount="20"
+            tools:layoutManager="GridLayoutManager"
+            tools:listitem="@layout/item_shortcut"
+            tools:spanCount="3" />
+
+    </LinearLayout>
 
     <include
         android:id="@+id/layout_noContent"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,6 +16,7 @@
   -->
 
 <resources>
+    <string name="grid_filter_hint">Filtrer par nom…</string>
     <string name="grid_snackbar_error_action_retry">Réessayer</string>
     <string name="grid_snackbar_generic_error_title">Une erreur est survenue.</string>
     <string name="grid_snackbar_loading_error_title">Impossible de charger vos appareils : %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,9 +23,9 @@
 
     <string name="menu_item_done">Done</string>
     <string name="menu_item_edit">Reorganize</string>
-    <string name="menu_item_hide_all">Hide all entities</string>
+    <string name="menu_item_hide_all">Hide all visible</string>
     <string name="menu_item_settings">Settings</string>
-    <string name="menu_item_show_all">Show all entities</string>
+    <string name="menu_item_show_all">Show all visible</string>
 
     <string name="item_hidden_contentDescription">This device is hidden</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
   -->
 
 <resources>
+    <string name="grid_filter_hint">Filter by name…</string>
     <string name="grid_snackbar_error_action_retry">Retry</string>
     <string name="grid_snackbar_generic_error_title">An error occurred.</string>
     <string name="grid_snackbar_loading_error_title">Could not load your devices: %s</string>

--- a/common/src/main/java/fr/outadoc/homeslide/common/feature/grid/vm/EntityListViewModel.kt
+++ b/common/src/main/java/fr/outadoc/homeslide/common/feature/grid/vm/EntityListViewModel.kt
@@ -161,7 +161,9 @@ class EntityListViewModel(
 
     fun showAll() = actionOn<State.Editing> { currentState ->
         val newList = currentState.allTiles.map { tile ->
-            tile.copy(isHidden = false)
+            if (tile in currentState.displayTiles) {
+                tile.copy(isHidden = false)
+            } else tile
         }
 
         setState { currentState.copy(allTiles = newList) }
@@ -169,7 +171,9 @@ class EntityListViewModel(
 
     fun hideAll() = actionOn<State.Editing> { currentState ->
         val newList = currentState.allTiles.map { tile ->
-            tile.copy(isHidden = true)
+            if (tile in currentState.displayTiles) {
+                tile.copy(isHidden = true)
+            } else tile
         }
 
         setState { currentState.copy(allTiles = newList) }


### PR DESCRIPTION
This PR adds a filtering box when in edit mode on mobile.

Additionally, "show/hide all" buttons will only affect filtered entities, because this makes way more sense.

Closes #351