### PR TITLE
feat(onboarding): remove use of discovery_info for HASS 2021.10 compatibility

### DIFF
--- a/app/src/main/java/fr/outadoc/homeslide/app/MainApplication.kt
+++ b/app/src/main/java/fr/outadoc/homeslide/app/MainApplication.kt
@@ -36,6 +36,7 @@ import fr.outadoc.homeslide.app.onboarding.feature.success.SuccessViewModel
 import fr.outadoc.homeslide.app.onboarding.feature.welcome.WelcomeViewModel
 import fr.outadoc.homeslide.app.preferences.PreferencePublisher
 import fr.outadoc.homeslide.app.preferences.PreferenceRepositoryImpl
+import fr.outadoc.homeslide.common.feature.auth.repository.InstanceConfigRepositoryImpl
 import fr.outadoc.homeslide.common.feature.consent.ConsentPreferenceRepository
 import fr.outadoc.homeslide.common.feature.daynight.ThemePreferenceRepository
 import fr.outadoc.homeslide.common.feature.details.vm.EntityDetailViewModel
@@ -51,6 +52,7 @@ import fr.outadoc.homeslide.hassapi.api.AuthApi
 import fr.outadoc.homeslide.hassapi.api.DiscoveryApi
 import fr.outadoc.homeslide.hassapi.api.HomeAssistantApi
 import fr.outadoc.homeslide.hassapi.repository.DiscoveryRepository
+import fr.outadoc.homeslide.hassapi.repository.InstanceConfigRepository
 import fr.outadoc.homeslide.logging.KLog
 import fr.outadoc.homeslide.rest.ApiClientBuilder
 import fr.outadoc.homeslide.rest.NetworkAccessManager
@@ -101,6 +103,7 @@ class MainApplication : Application() {
 
         single<ZeroconfDiscoveryService<ZeroconfHost>> { HassZeroconfDiscoveryServiceImpl(get()) }
         single<DiscoveryRepository> { DiscoveryRepositoryImpl(get()) }
+        single<InstanceConfigRepository> { InstanceConfigRepositoryImpl(get()) }
         single<IntentProvider> { AppIntentProvider() }
 
         single { PreferenceRepositoryImpl(get(), get()) }
@@ -131,7 +134,7 @@ class MainApplication : Application() {
                 get()
             )
         }
-        viewModel { AuthCallbackViewModel(get(), get(), get()) }
+        viewModel { AuthCallbackViewModel(get(), get(), get(), get(), get()) }
         viewModel { ShortcutSetupViewModel() }
         viewModel {
             SuccessViewModel(

--- a/app/src/main/java/fr/outadoc/homeslide/app/feature/grid/ui/EntityGridFragment.kt
+++ b/app/src/main/java/fr/outadoc/homeslide/app/feature/grid/ui/EntityGridFragment.kt
@@ -105,7 +105,9 @@ class EntityGridFragment : Fragment() {
         onBackPressedCallback = requireActivity()
             .onBackPressedDispatcher
             .addCallback(this) {
-                vm.exitEditMode()
+                if (vm.getStateOrNull<State>() is State.Editing) {
+                    vm.exitEditMode()
+                }
             }
     }
 

--- a/common/src/main/java/fr/outadoc/homeslide/common/feature/auth/repository/InstanceConfigRepositoryImpl.kt
+++ b/common/src/main/java/fr/outadoc/homeslide/common/feature/auth/repository/InstanceConfigRepositoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Baptiste Candellier
+ * Copyright 2021 Baptiste Candellier
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  *    limitations under the License.
  */
 
-package fr.outadoc.homeslide.hassapi.model.discovery
+package fr.outadoc.homeslide.common.feature.auth.repository
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import fr.outadoc.homeslide.hassapi.api.HomeAssistantApi
+import fr.outadoc.homeslide.hassapi.model.discovery.Config
+import fr.outadoc.homeslide.hassapi.repository.InstanceConfigRepository
+import fr.outadoc.homeslide.rest.util.getResponseOrThrow
 
-@Serializable
-data class ApiStatus(
-    @SerialName("message")
-    val message: String
-)
+class InstanceConfigRepositoryImpl(
+    private val api: HomeAssistantApi
+): InstanceConfigRepository {
+    override suspend fun getConfig(): Config = api.getConfig().getResponseOrThrow()
+}

--- a/common/src/main/java/fr/outadoc/homeslide/common/feature/auth/repository/InstanceConfigRepositoryImpl.kt
+++ b/common/src/main/java/fr/outadoc/homeslide/common/feature/auth/repository/InstanceConfigRepositoryImpl.kt
@@ -23,6 +23,6 @@ import fr.outadoc.homeslide.rest.util.getResponseOrThrow
 
 class InstanceConfigRepositoryImpl(
     private val api: HomeAssistantApi
-): InstanceConfigRepository {
+) : InstanceConfigRepository {
     override suspend fun getConfig(): Config = api.getConfig().getResponseOrThrow()
 }

--- a/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/authcallback/AuthCallbackViewModel.kt
+++ b/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/authcallback/AuthCallbackViewModel.kt
@@ -18,8 +18,12 @@ package fr.outadoc.homeslide.app.onboarding.feature.authcallback
 
 import fr.outadoc.homeslide.app.onboarding.navigation.NavigationEvent
 import fr.outadoc.homeslide.common.preferences.TokenPreferenceRepository
+import fr.outadoc.homeslide.common.preferences.UrlPreferenceRepository
+import fr.outadoc.homeslide.hassapi.model.auth.Token
 import fr.outadoc.homeslide.hassapi.model.auth.expiresInDuration
+import fr.outadoc.homeslide.hassapi.model.discovery.Config
 import fr.outadoc.homeslide.hassapi.repository.AuthRepository
+import fr.outadoc.homeslide.hassapi.repository.InstanceConfigRepository
 import fr.outadoc.homeslide.logging.KLog
 import io.uniflow.android.AndroidDataFlow
 import kotlinx.coroutines.Dispatchers
@@ -29,6 +33,8 @@ import kotlinx.datetime.Clock
 class AuthCallbackViewModel(
     private val tokenPrefs: TokenPreferenceRepository,
     private val authRepository: AuthRepository,
+    private val configRepository: InstanceConfigRepository,
+    private val urlPreferenceRepository: UrlPreferenceRepository,
     private val clock: Clock
 ) : AndroidDataFlow() {
 
@@ -37,18 +43,31 @@ class AuthCallbackViewModel(
 
         withContext(Dispatchers.IO) {
             try {
-                val token = authRepository.getToken(code)
-                withContext(Dispatchers.Main) {
-                    // Save the auth code
-                    tokenPrefs.accessToken = token.accessToken
-                    tokenPrefs.refreshToken = token.refreshToken
-                    tokenPrefs.tokenExpirationTime = clock.now() + token.expiresInDuration
-                }
-
-                sendEvent { NavigationEvent.Next }
+                authRepository.getToken(code).saveTokenToPrefs()
             } catch (e: Exception) {
                 KLog.e(e) { "couldn't retrieve token using code $code" }
             }
+
+            try {
+                configRepository.getConfig().saveInstanceBaseUrlsToPrefs()
+            } catch (e: Exception) {
+                KLog.e(e) { "Error while fetching base URL configuration" }
+            }
+
+            sendEvent { NavigationEvent.Next }
+        }
+    }
+
+    private fun Token.saveTokenToPrefs() {
+        tokenPrefs.accessToken = accessToken
+        tokenPrefs.refreshToken = refreshToken
+        tokenPrefs.tokenExpirationTime = clock.now() + expiresInDuration
+    }
+
+    private fun Config.saveInstanceBaseUrlsToPrefs() {
+        if (!localBaseUrl.isNullOrEmpty() || !remoteBaseUrl.isNullOrEmpty() || !baseUrl.isNullOrEmpty()) {
+            urlPreferenceRepository.localInstanceBaseUrl = localBaseUrl ?: baseUrl
+            urlPreferenceRepository.remoteInstanceBaseUrl = remoteBaseUrl ?: baseUrl
         }
     }
 }

--- a/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/host/rest/DiscoveryRepositoryImpl.kt
+++ b/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/host/rest/DiscoveryRepositoryImpl.kt
@@ -17,17 +17,15 @@
 package fr.outadoc.homeslide.app.onboarding.feature.host.rest
 
 import fr.outadoc.homeslide.hassapi.api.DiscoveryApi
-import fr.outadoc.homeslide.hassapi.model.discovery.ApiStatus
-import fr.outadoc.homeslide.hassapi.model.discovery.DiscoveryInfo
 import fr.outadoc.homeslide.hassapi.repository.DiscoveryRepository
-import fr.outadoc.homeslide.rest.util.getResponseOrThrow
 
-class DiscoveryRepositoryImpl(private val client: DiscoveryApi) :
-    DiscoveryRepository {
+class DiscoveryRepositoryImpl(private val client: DiscoveryApi) : DiscoveryRepository {
 
-    override suspend fun getDiscoveryInfo(baseUrl: String): DiscoveryInfo =
-        client.getDiscoveryInfo(baseUrl).getResponseOrThrow()
-
-    override suspend fun getApiStatus(baseUrl: String, token: String): ApiStatus =
-        client.getApiStatus(baseUrl, "Bearer $token").getResponseOrThrow()
+    override suspend fun isInstanceReachable(baseUrl: String): Boolean {
+        // If we get a 200 OK response, we're good.
+        // If we get a 401 Unauthorized, it's expected - we haven't sent a token, assume we're good.
+        val validResponseCodes = listOf(200, 401)
+        val responseCode = client.getApiStatus(baseUrl, token = null).code()
+        return responseCode in validResponseCodes
+    }
 }

--- a/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/host/rest/DiscoveryRepositoryImpl.kt
+++ b/feature-onboarding/src/main/java/fr/outadoc/homeslide/app/onboarding/feature/host/rest/DiscoveryRepositoryImpl.kt
@@ -22,10 +22,10 @@ import fr.outadoc.homeslide.hassapi.repository.DiscoveryRepository
 class DiscoveryRepositoryImpl(private val client: DiscoveryApi) : DiscoveryRepository {
 
     override suspend fun isInstanceReachable(baseUrl: String): Boolean {
+        val response = client.getApiStatus(baseUrl, token = null)
+
         // If we get a 200 OK response, we're good.
         // If we get a 401 Unauthorized, it's expected - we haven't sent a token, assume we're good.
-        val validResponseCodes = listOf(200, 401)
-        val responseCode = client.getApiStatus(baseUrl, token = null).code()
-        return responseCode in validResponseCodes
+        return response.isSuccessful || response.code() == 401
     }
 }

--- a/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/api/DiscoveryApi.kt
+++ b/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/api/DiscoveryApi.kt
@@ -16,8 +16,6 @@
 
 package fr.outadoc.homeslide.hassapi.api
 
-import fr.outadoc.homeslide.hassapi.model.discovery.ApiStatus
-import fr.outadoc.homeslide.hassapi.model.discovery.DiscoveryInfo
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -25,14 +23,9 @@ import retrofit2.http.Path
 
 interface DiscoveryApi {
 
-    @GET("{baseUrl}/api/discovery_info")
-    suspend fun getDiscoveryInfo(
-        @Path("baseUrl", encoded = true) baseUrl: String
-    ): Response<DiscoveryInfo>
-
     @GET("{baseUrl}/api/")
     suspend fun getApiStatus(
         @Path("baseUrl", encoded = true) baseUrl: String,
-        @Header("Authorization") token: String
-    ): Response<ApiStatus>
+        @Header("Authorization") token: String?
+    ): Response<Void>
 }

--- a/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/api/HomeAssistantApi.kt
+++ b/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/api/HomeAssistantApi.kt
@@ -17,6 +17,7 @@
 package fr.outadoc.homeslide.hassapi.api
 
 import fr.outadoc.homeslide.hassapi.model.EntityState
+import fr.outadoc.homeslide.hassapi.model.discovery.Config
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -34,4 +35,7 @@ interface HomeAssistantApi {
         @Path("service") service: String,
         @Body params: Map<String, String>
     ): Response<List<EntityState>>
+
+    @GET("/api/config")
+    suspend fun getConfig(): Response<Config>
 }

--- a/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/model/discovery/Config.kt
+++ b/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/model/discovery/Config.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiscoveryInfo(
+data class Config(
 
     @SerialName("base_url")
     val baseUrl: String? = null,

--- a/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/repository/DiscoveryRepository.kt
+++ b/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/repository/DiscoveryRepository.kt
@@ -16,11 +16,6 @@
 
 package fr.outadoc.homeslide.hassapi.repository
 
-import fr.outadoc.homeslide.hassapi.model.discovery.ApiStatus
-import fr.outadoc.homeslide.hassapi.model.discovery.DiscoveryInfo
-
 interface DiscoveryRepository {
-
-    suspend fun getDiscoveryInfo(baseUrl: String): DiscoveryInfo
-    suspend fun getApiStatus(baseUrl: String, token: String): ApiStatus
+    suspend fun isInstanceReachable(baseUrl: String): Boolean
 }

--- a/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/repository/InstanceConfigRepository.kt
+++ b/lib-homeassistant-api/src/main/java/fr/outadoc/homeslide/hassapi/repository/InstanceConfigRepository.kt
@@ -14,13 +14,10 @@
  *    limitations under the License.
  */
 
-package fr.outadoc.homeslide.hassapi.model.discovery
+package fr.outadoc.homeslide.hassapi.repository
 
-data class ValidatedDiscoveryInfo(val localBaseUrl: String, val remoteBaseUrl: String?)
+import fr.outadoc.homeslide.hassapi.model.discovery.Config
 
-fun DiscoveryInfo.validate(): ValidatedDiscoveryInfo? {
-    return ValidatedDiscoveryInfo(
-        localBaseUrl = localBaseUrl ?: baseUrl ?: return null,
-        remoteBaseUrl = remoteBaseUrl ?: baseUrl
-    )
+interface InstanceConfigRepository {
+    suspend fun getConfig(): Config
 }


### PR DESCRIPTION
Home Assistant 2021.10 deprecated the ` discovery_info`  route, which caused problems during onboarding.

The new onboarding flow systematically uses the URL provided by the user for authentication (or the local url for zeroconf), and fetches the instance config with the ` /api/config`  route once authenticated. The proper base URLs setup in the instance are then saved to preferences.

Closes #410 